### PR TITLE
README.md: fixed link for akka.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/gamazeps/RobotS.svg?branch=travis__test)](https://travis-ci.org/gamazeps/RobotS)
 
-Robots is a pure rust actor system library, it is meant to be a close implementation of [akka](akka.io).
+Robots is a pure rust actor system library, it is meant to be a close implementation of [akka](http://akka.io).
 
 Documentation can be found [here](http://gamazeps.github.io/RobotS/).
 


### PR DESCRIPTION
Hi! Just looking at this library, I noticed a broken link in README.md so here's the fix :)
