### PR TITLE
Fix moved links

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ impl Actor for Printer {
 As you can see this is rather easy.
 
 If you think that using Box&lt;Any> is very bad and that someone should do terrible things to me, check
-[this post](http://gamazeps.github.io/why-boxany.html) before :)
+[this post](http://gamazeps.github.io/posts/robots_any.html) before :)
 
 ### ActorContext methods
 

--- a/src/actors/future.rs
+++ b/src/actors/future.rs
@@ -87,7 +87,7 @@ impl Actor for Future {
             },
             Err(message) => {
                 // The double downgrade is ugly but we can't have an enum containing the two
-                // variants (see http://gamazeps.github.io/notes-7.html).
+                // variants (see http://gamazeps.github.io/posts/robots_notes_7.html).
                 if let Ok(msg) = Box::<Any>::downcast::<Complete>(message) {
                     // We need to free the lock on the state.
                     {


### PR DESCRIPTION
The website seems to have been rearranged, so the background info linked form the repo has different URLs.